### PR TITLE
don't remove exit() class function

### DIFF
--- a/R/cleaner.R
+++ b/R/cleaner.R
@@ -55,6 +55,9 @@
     # first <- grep("#include", tx)[1]
     # tx[first]  <- sub(pattern = "#include",   replacement = "#include <Rcpp.h>\n#include", x = tx[first])
     tx[1] <- paste0("#include <Rcpp.h>\n", tx[1])
+    tx[search]  <- gsub(pattern = "std::tuple<Locate_type, int, int> exit\\(\\) const", 
+                    replacement="std::tuple<Locate_type, int, int\\> exit_tmp\\(\\) const", 
+                    x = tx[search])
     tx[search]  <- gsub(pattern = "std::cerr", replacement = "Rcpp::Rcerr", x = tx[search])
     tx[search]  <- gsub(pattern = "std::cout", replacement = "Rcpp::Rcout", x = tx[search])
     tx[search]  <- gsub(pattern = "std::abort\\(\\)", replacement = 'Rcpp::stop("Error")', x = tx[search])
@@ -63,6 +66,9 @@
     tx[search]  <- gsub(pattern = " exit\\(\\)", replacement = 'Rcpp::stop("Error")', x = tx[search])
     tx[search]  <- gsub(pattern = "std::exit\\(0\\)", replacement = 'Rcpp::stop("Success")', x = tx[search])
     tx[search]  <- gsub(pattern = "std::exit\\(1\\)", replacement = 'Rcpp::stop("Error")', x = tx[search])
+    tx[search]  <- gsub(pattern = "std::tuple<Locate_type, int, int> exit_tmp\\(\\) const", 
+                    replacement="std::tuple<Locate_type, int, int\\> exit\\(\\) const", 
+                    x = tx[search])
     writeLines(tx, con=f)
   }
   cgal_pkg_state$CLEANED <- TRUE


### PR DESCRIPTION
This fixes the compilation error seen in gcc 13.2 that caused the downstream cgalMeshes package to fail to compile.